### PR TITLE
Update ch03.tex

### DIFF
--- a/src/ch03.tex
+++ b/src/ch03.tex
@@ -643,7 +643,7 @@ Rust有三种表示一系列值的类型：
             let mut j = i * i;
             while j < 10000 {
                 sieve[j] = false;
-                j += 1;
+                j += i;
             }
         }
     }


### PR DESCRIPTION
3.6.1示例代码为埃氏筛，应为`j += i`